### PR TITLE
Call player.setSrc with string instead of array to avoid call to canPlayType

### DIFF
--- a/app/assets/javascripts/mediaelement-qualityselector/mep-feature-qualities.js
+++ b/app/assets/javascripts/mediaelement-qualityselector/mep-feature-qualities.js
@@ -61,7 +61,8 @@
 			}
 			
 			// Sets the player to use the selected quality
-			player.setSrc([{src: player.qualities[selectedIndex].getAttribute("src"), type: player.qualities[selectedIndex].getAttribute("type")}]);
+			// Use the string parameter to avoid checking canPlayType
+			player.setSrc(player.qualities[selectedIndex].getAttribute("src"));
 			player.selectedQuality = player.qualities[selectedIndex].getAttribute("data-quality");
 		},
 


### PR DESCRIPTION
which returns bad values on android for HLS
